### PR TITLE
Minor Update in opening Tamil files

### DIFF
--- a/VaaniNLP/tamil/vaaninlp.py
+++ b/VaaniNLP/tamil/vaaninlp.py
@@ -50,7 +50,7 @@ def weight(a):
   return result
 
 def remove_stopwords(words):
-  stop_words_list = open(os.path.dirname(os.path.abspath(__file__))+"/stop_words.txt", "r").read().split("\n")
+  stop_words_list = open(os.path.dirname(os.path.abspath(__file__))+"/stop_words.txt", "r", encoding='utf-8').read().split("\n")
   new_words =[]
   for i in words:
     if i not in stop_words_list:


### PR DESCRIPTION
Minor Update in opening Tamil files.
Tamil files are in UTF-8 encoding.
Due to the code not specifying the encoding type

`open(os.path.dirname(os.path.abspath(__file__))+"/stop_words.txt", "r") `

Python takes default encoding the OS encoding type,  (locale.getpreferredencoding() to get the encoding type) EX:  Windows 11 encoding type - CP1252
       Google Colab encoding type - UTF-8

while running the above code in Colab no issues, but while running Windows 11 it gives a decoding error due to a different encoding CP1252 for UTF-8.

to resolve this issue we can give the encoding type externally,

`open(os.path.dirname(os.path.abspath(__file__))+"/stop_words.txt", "r", encoding='utf-8')`

encoding='utf-8' - tells that it is  opening a file encoding UTF-8,

after this change, the code works fine on all the machines, checked with Linux and Windows and Google Colab